### PR TITLE
fix: resolved switch auto break assumption

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -318,14 +318,18 @@ func alertThresholdFilterVulnerabilityCount(diffVulnerabilityCount Vulnerability
 		Low:      formatInt32(diffVulnerabilityCount.Low),
 	}
 
-	switch {
-	case !contains(alertThresholdList, "Critical"):
+	// switch statements auto break and don't have a non break option?
+	// what a crazy world.
+	if !contains(alertThresholdList, "Critical") {
 		strStruct.Critical = ""
-	case !contains(alertThresholdList, "High"):
+	}
+	if !contains(alertThresholdList, "High") {
 		strStruct.High = ""
-	case !contains(alertThresholdList, "Medium"):
+	}
+	if !contains(alertThresholdList, "Medium") {
 		strStruct.Medium = ""
-	case !contains(alertThresholdList, "Low"):
+	}
+	if !contains(alertThresholdList, "Low") {
 		strStruct.Low = ""
 	}
 


### PR DESCRIPTION
## Problem
Linked to issue #4 output not matching request for filtering. 

## Solved
So it turns out that go auto break within a switch statement so we were hitting the first true case and exiting the switch. 
Looked into options to not break and found `fallthrough` but this just pushed you into the case under it?
[clearly some confusion here](https://stackoverflow.com/questions/40821855/do-go-switch-cases-fallthrough-or-not)

Maybe I'm missing something here but couldn't find any explanation. Fixed by replacing switch with 4 if statements. 

![headshake-bobby](https://user-images.githubusercontent.com/80027170/190846288-ccbf213d-2e57-4e14-a3b5-f97708463368.gif)
