### PR TITLE
fix: no var to tell if alerted

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,6 +15,7 @@ var scanHistory req.ScanHistory
 var alertThresholdList []string
 var alertThresholdListInt []int
 var scanTimeout = 100
+var alerted = false
 
 var ApiKey string
 
@@ -227,9 +228,9 @@ returns json object with count difference and list of vulnerabilities listed in 
 			log.Errorf("Failed to marshal diff count output")
 			os.Exit(1)
 		}
-		loggingDiff(diffVulnerabilityCount)
+		doesItDiff(diffVulnerabilityCount)
 		fmt.Println(string(response))
-		if exitWithError {
+		if exitWithError && alerted {
 			os.Exit(1)
 		}
 	},
@@ -279,21 +280,25 @@ func sortVulnerabilities(vulnerabilities []req.Vulnerability) []req.Vulnerabilit
 	return vulnerabilities
 }
 
-//loggingDiff Qualifies if results in the diff are worth being and asked to be logged.
-func loggingDiff(diffVulnerabilityCount VulnerabilityCount) {
+//doesItDiff Qualifies if there are diffs in the diff and if the user wants them alerted.
+func doesItDiff(diffVulnerabilityCount VulnerabilityCount) {
 
 	for _, alertThreshold := range alertThresholdList {
 
 		if alertThreshold == "Critical" && diffVulnerabilityCount.Critical > 0 {
+			alerted = true
 			outLogDiff(alertThreshold)
 		}
 		if alertThreshold == "High" && diffVulnerabilityCount.High > 0 {
+			alerted = true
 			outLogDiff(alertThreshold)
 		}
 		if alertThreshold == "Medium" && diffVulnerabilityCount.Medium > 0 {
+			alerted = true
 			outLogDiff(alertThreshold)
 		}
 		if alertThreshold == "Low" && diffVulnerabilityCount.Low > 0 {
+			alerted = true
 			outLogDiff(alertThreshold)
 		}
 	}


### PR DESCRIPTION
## Problem 
Missed an obvious issue in #3 by moving the exit out and not adding in any info to tell if it has alerted.
Leaving it to error on every run, even when no vulnerabilities were found. 
![image](https://user-images.githubusercontent.com/80027170/190847073-b91c5b3a-7927-4f4c-af32-ee1ffffb26e4.png)

## Solution
Creating an alerted var that gets set when vulnerabilities are found. Chose to rename the previous logging function to a general function for if it diffs as that makes more sense. 